### PR TITLE
Update valetudo-map-card.js

### DIFF
--- a/src/valetudo-map-card.js
+++ b/src/valetudo-map-card.js
@@ -22,7 +22,7 @@ class ValetudoMapCard extends HTMLElement {
         this.lastMapPoll = new Date(0);
         this.isPollingMap = false;
         this.lastRobotState = "docked";
-        this.pollInterval = POLL_INTERVAL_STATE_MAP["cleaning"];
+        this.pollInterval = POLL_INTERVAL_STATE_MAP["docked"];
 
         this.cardContainer = document.createElement("ha-card");
         this.cardContainer.id = "valetudoMapCard";


### PR DESCRIPTION
Fixed default poll interval to "docked" state to match assumed lastRobotState.  This solves the issue of new page loads for docked robots reloading and redrawing the map evey 3 seconds instead of every 120 seconds as intended.